### PR TITLE
Move cache expire time to localenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-./includes/localenv.php
+includes/localenv.php
+cache

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -53,7 +53,7 @@ function getGaiaCompletion($gaia)
 }
 
 
-function cacheUrl($url, $time = 600)
+function cacheUrl($url, $time = CACHE_EXPIRE)
 {
     $cache = CACHE . sha1($url) . '.cache';
     if (is_file($cache)) {

--- a/includes/init.php
+++ b/includes/init.php
@@ -20,6 +20,9 @@ require_once  __DIR__ .'/localenv.php';
 
 define('CACHE', $cachePath);
 
+$cacheExpire = !empty($cacheExpire) ? $cacheExpire : 600;
+define('CACHE_EXPIRE', $cacheExpire);
+
 // Set debug environment
 if(DEBUG) {
     error_reporting(E_ALL);

--- a/includes/localenv.php-dist
+++ b/includes/localenv.php-dist
@@ -2,3 +2,7 @@
 
 // Path to cache
 $cachePath = '/path/to/fxosl10ndashboard/cache/';
+
+// Cache expire (seconds), default 10 minutes
+$cacheExpire = 600;
+


### PR DESCRIPTION
Fixed .gitignore to really ignore localenv.php and cache.
Moved expire time to a constant defined in localenv.php
