### PR TITLE
Fix Portoguese

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -99,7 +99,6 @@ function normalizeGaiaLocales($gaia)
     $map = [
         'es'      => 'es-ES',
         'pa'      => 'pa-IN',
-        'pt'      => 'pt-BR',
         'sr-Cyrl' => 'sr',
     ];
 


### PR DESCRIPTION
Marketplace data are missing (searching for pt instead of pt-BR).

"pt" is used only for some Marketplace unrelated projects
http://l10n.mozilla-community.org/~flod/webstatus/?locale=pt
